### PR TITLE
Add tests for endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ VoiceNote is a Flask-based web application that provides audio and video transcr
 
 4. Wait for the transcription to complete and download the result
 
+## Running Tests
+
+The repository includes a small test suite that can be executed with Python's
+built-in `unittest` module. From the project root run:
+
+```bash
+python -m unittest discover -s tests
+```
+
 ## Project Structure
 
 The application follows a standard Flask project structure:
@@ -57,6 +66,8 @@ VoiceNote/
 │       └── main.js      # JavaScript for UI interactivity
 ├── templates/
 │   └── index.html       # HTML template for the web interface
+├── tests/               # Unit tests
+│   └── test_endpoints.py
 └── README.md            # Project documentation
 ```
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,41 @@
+import io
+import unittest
+import importlib
+from unittest.mock import patch, MagicMock
+
+flask_spec = importlib.util.find_spec("flask")
+celery_spec = importlib.util.find_spec("celery")
+flask_available = flask_spec is not None and celery_spec is not None
+
+if flask_available:
+    from voicenote import app
+else:
+    app = None
+
+
+@unittest.skipUnless(flask_available, "Flask and Celery are required")
+class EndpointsTestCase(unittest.TestCase):
+    def setUp(self):
+        app.config['TESTING'] = True
+        self.client = app.test_client()
+
+    def test_home_status_code(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+
+    @patch('voicenote.transcribe_audio.delay')
+    def test_transcribe_returns_202(self, mock_delay):
+        mock_task = MagicMock()
+        mock_task.id = 'dummy-task-id'
+        mock_delay.return_value = mock_task
+
+        data = {
+            'file': (io.BytesIO(b'dummy'), 'dummy.wav')
+        }
+        response = self.client.post('/transcribe', data=data,
+                                    content_type='multipart/form-data')
+        self.assertEqual(response.status_code, 202)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for key HTTP endpoints
- document how to run the tests in README
- update project structure diagram to include tests directory

## Testing
- `python3 -m unittest discover -s tests` (tests skipped due to missing dependencies)