### PR TITLE
Fix Kotoba v2.2 speaker diarization (pipeline/dtype/torch2.6/deps)

### DIFF
--- a/engines/kotoba_engine.py
+++ b/engines/kotoba_engine.py
@@ -62,15 +62,50 @@ class KotobaEngine(STTEngine):
             device_str,
             self.diarization,
         )
-        self._pipe = pipeline(
-            "automatic-speech-recognition",
-            model=self.model_id,
-            torch_dtype=torch_dtype,
-            device=device_str,
-            model_kwargs=model_kwargs,
-            batch_size=8,
-            trust_remote_code=True,
-        )
+        def _build_pipeline(*args, **kwargs):
+            # dtype は model_kwargs に入れる。新しい transformers では top-level の
+            # dtype=/torch_dtype= を model_kwargs と併用すると（model_kwargs 側に dtype が
+            # 無くても）dtype 競合の ValueError になるため。新版は "dtype"、旧版は "torch_dtype"。
+            mk = dict(kwargs.pop("model_kwargs", {}) or {})
+            try:
+                return pipeline(*args, model_kwargs={**mk, "dtype": torch_dtype}, **kwargs)
+            except TypeError:
+                return pipeline(*args, model_kwargs={**mk, "torch_dtype": torch_dtype}, **kwargs)
+
+        if self.diarization:
+            # v2.2: 話者分離・句読点付与はモデル同梱のカスタムパイプラインが担う。
+            # task を "automatic-speech-recognition" に固定すると標準 Whisper パイプラインに
+            # なり add_punctuation が拒否されるため、task は指定せず trust_remote_code で
+            # カスタムパイプラインをロードする。
+            # また PyTorch 2.6 で torch.load の既定が weights_only=True になり、pyannote の
+            # チェックポイント(TorchVersion 等のグローバルを含む)が読めなくなるため、信頼できる
+            # ローカルモデルに限り読み込み中だけ weights_only=False を強制する。
+            _orig_torch_load = torch.load
+
+            def _trusting_torch_load(*a, **k):
+                k["weights_only"] = False  # lightning が True を明示するため setdefault では不可
+                return _orig_torch_load(*a, **k)
+
+            torch.load = _trusting_torch_load
+            try:
+                self._pipe = _build_pipeline(
+                    model=self.model_id,
+                    device=device_str,
+                    model_kwargs=model_kwargs,
+                    batch_size=8,
+                    trust_remote_code=True,
+                )
+            finally:
+                torch.load = _orig_torch_load
+        else:
+            self._pipe = _build_pipeline(
+                "automatic-speech-recognition",
+                model=self.model_id,
+                device=device_str,
+                model_kwargs=model_kwargs,
+                batch_size=8,
+                trust_remote_code=True,
+            )
         self._loaded = True
 
     def transcribe(

--- a/voicenote.def
+++ b/voicenote.def
@@ -45,8 +45,16 @@ PY
     pip3 install transformers accelerate
 
     # Kotoba v2.2（話者分離）依存
-    pip3 install "punctuators==0.0.5" "pyannote.audio"
-    pip3 install git+https://github.com/huggingface/diarizers.git
+    # 重要(依存解決の罠):
+    # - pyannote.audio を版未指定で入れると、torch固定(PIP_CONSTRAINT)下で最新版を解決できず
+    #   依存のほぼ無い 1.1.2 まで後退して着地し、pyannote.audio.core が無く diarizers が import 失敗する。
+    # - diarizers を別コマンドで後入れすると、緩い依存指定により pyannote.audio を 1.1.2 へ巻き戻す。
+    # - 同梱の datasets 2.14 は pyarrow>=14 で削除された PyExtensionType を参照し、pyarrow24 で失敗する。
+    # 対策: pyannote.audio(3系) / datasets(3系) / diarizers を「同一 pip コマンド」で解決する。
+    #   datasets 4.x/5.x は datasets[audio] が torchcodec を要求し torch固定と衝突して長時間
+    #   バックトラックするため <4 で絞る（実機で 3.6.0 が解決・動作確認済み）。
+    pip3 install "punctuators==0.0.5"
+    pip3 install "pyannote.audio>=3.1,<4" "datasets>=3,<4" "git+https://github.com/huggingface/diarizers.git"
 
     # ReazonSpeech k2-v2（公式SDK + sherpa-onnx）
     git clone https://github.com/reazon-research/ReazonSpeech /opt/ReazonSpeech
@@ -90,6 +98,10 @@ PY
     cd /app
     python3 -c "import config; from engines.factory import EngineFactory; from engines.chunking import to_wav, transcribe_chunked; print('package layout OK:', EngineFactory)"
     python3 -c "import config; print('models loaded:', len(config.list_models()))"
+    # 話者分離(Kotoba v2.2)スタックの健全性をビルド時に検証する。
+    # pyannote.audio が 1.x に転落していたら（diarizers が動かない）ここでビルドを落とす。
+    python3 -c "import pyannote.audio as p; v=p.__version__; print('pyannote.audio', v); maj=int(v.split('.')[0]); assert 3 <= maj < 4, 'pyannote.audio must be 3.x for diarizers/kotoba-v2.2, got '+v"
+    python3 -c "import diarizers; print('diarizers import OK')"
 
 %environment
     CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}


### PR DESCRIPTION
## 概要

Kotoba-Whisper v2.2（`diarization: true`）が現行の依存・ランタイムで**文字起こしタスクごと失敗**する不具合を修正します。原因はロード経路上に複数層重なっており、実機（RTX 4090）で検証済みの引き継ぎ資料に基づきます。修正対象は `engines/kotoba_engine.py` と `voicenote.def` の2ファイルのみ。

## 直した層（症状 → 原因 → 対処）

| 症状 | 原因 | 対処 |
|---|---|---|
| `model_kwargs are not used: ['add_punctuation']` | v2.2を標準ASRパイプラインでロードしていた | **task指定なし**＋`trust_remote_code`でモデル同梱のカスタムpipelineをロード |
| `No module named 'pyannote.audio.core'` | torch固定下で `pyannote.audio` が **1.1.2 に転落** | `pyannote.audio>=3.1,<4` に固定 |
| `pyarrow has no attribute 'PyExtensionType'` | `datasets 2.14` × `pyarrow 24` | `datasets>=3,<4` に固定 |
| `You cannot use both dtype=..., model_kwargs={"dtype":...}` | 新transformersで top-level dtype と model_kwargs 併用 | **dtypeを `model_kwargs` 内へ**（新版`dtype`/旧版`torch_dtype`） |
| `Weights only load failed ... TorchVersion` | torch 2.6 で `torch.load` 既定が `weights_only=True` | 話者分離チェックポイント読込中のみ `weights_only=False` を強制（直後に復元） |

依存の3パッケージ（`pyannote.audio` / `datasets` / `diarizers`）は**同一 pip コマンド**で解決し、巻き戻しを防止。`%test` に `pyannote.audio` が 3.x であることのアサーションと `diarizers` import を追加し、**転落をビルド時に検知**します。

## 動作確認

- 修正後、v2.2 で `SPEAKER_00: …` の話者ラベル付き文字起こしを RTX 4090 で確認済み（引き継ぎ資料）。
- `transcribe()` は変更不要（既存の `add_punctuation=True` 呼び出しがカスタムpipelineで正しく動作）。
- 既存ユニットテスト（config/factory/endpoints/chunking）は影響なし（`load()` は遅延importで、テストはモデルをロードしない）。

## 運用前提（コード外・READMEに記載済み）

- HuggingFace の gated モデル（`pyannote/speaker-diarization-3.1`, `pyannote/segmentation-3.0`）の利用規約に同一アカウントで同意。
- そのトークンを `SINGULARITYENV_HF_TOKEN=hf_xxx` で渡す。

## スコープ外（取り込まないもの）

引き継ぎ資料のローカルフォーク拡張（Ollama後処理 `postprocess/`・成果物管理 `artifacts/`・`validation.py` 等）は **main 非対象**のため本PRには含めません。本PRは v2.2 話者分離の修正のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
